### PR TITLE
Don't require re-defining equals() method if not needed

### DIFF
--- a/src/nl/jqno/equalsverifier/FieldsChecker.java
+++ b/src/nl/jqno/equalsverifier/FieldsChecker.java
@@ -167,8 +167,10 @@ class FieldsChecker<T> implements Checker {
 						!thisFieldShouldBeUsed || equalsChanged);
 				assertTrue(Formatter.of("Significant fields: equals should not use %%, but it does.", fieldName),
 						thisFieldShouldBeUsed || !equalsChanged);
-				assertTrue(Formatter.of("Significant fields: all fields should be used, but %% has not defined an equals method.", classAccessor.getType().getSimpleName()),
-						classAccessor.declaresEquals());
+				if (classAccessor.declaresField(referenceAccessor.getField())) {
+					assertTrue(Formatter.of("Significant fields: all fields should be used, but %% has not defined an equals method.", classAccessor.getType().getSimpleName()),
+					classAccessor.declaresEquals());
+				}
 			}
 			
 			referenceAccessor.changeField(prefabValues);

--- a/src/nl/jqno/equalsverifier/util/ClassAccessor.java
+++ b/src/nl/jqno/equalsverifier/util/ClassAccessor.java
@@ -97,7 +97,22 @@ public class ClassAccessor<T> {
 	public boolean fieldHasAnnotation(Field field, Annotation annotation) {
 		return annotationAccessor.fieldHas(field.getName(), annotation);
 	}
-	
+
+	/**
+	 * Determines whether T declares a field.  This does not include inherited fields.
+	 *
+	 * @return True if T declares the field.
+	 */
+	public boolean declaresField(Field field) {
+		try {
+			type.getDeclaredField(field.getName());
+			return true;
+		}
+		catch (NoSuchFieldException e) {
+			return false;
+		}
+	}
+
 	/**
 	 * Determines whether T has an {@code equals} method.
 	 * 

--- a/test/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
+++ b/test/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
@@ -93,6 +93,13 @@ public class SignificantFieldsTest extends IntegrationTestBase {
 		EqualsVerifier.forClass(NoFieldsUsed.class)
 				.verify();
 	}
+
+	@Test
+	public void succeed_whenNoFieldsAreAdded_givenAllFieldsShouldBeUsed() {
+		EqualsVerifier.forClass(NoFieldsAdded.class)
+				.allFieldsShouldBeUsed()
+				.verify();
+	}
 	
 	@Test
 	public void fail_whenNoFieldsAreUsed_givenAllFieldsShouldBeUsed() {
@@ -277,7 +284,13 @@ public class SignificantFieldsTest extends IntegrationTestBase {
 		
 		public NoFieldsUsed(Color color) { this.color = color; }
 	}
-	
+
+	static final class NoFieldsAdded extends Point {
+		public NoFieldsAdded(int x, int y) {
+			super(x, y);
+		}
+	}
+
 	static final class TwoFieldsUnusedColorPoint {
 		private final int x;
 		private final int y;


### PR DESCRIPTION
This change relaxes the requirement to define `equals()` when using `allFieldsShouldBeUsed()` iff a class does not add any new properties.  Currently, a class is forced to redefine `equals()` even if it is simply calling the parent class's implementation.
