### PR TITLE
Sort modifiers according to canonical preferred order

### DIFF
--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/AbstractDelegationTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/AbstractDelegationTest.java
@@ -153,7 +153,7 @@ public class AbstractDelegationTest extends IntegrationTestBase {
 				.verify();
 	}
 	
-	private static abstract class AbstractClass {
+	private abstract static class AbstractClass {
 		private int i;
 		
 		abstract void someMethod();
@@ -186,7 +186,7 @@ public class AbstractDelegationTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class AbstractEqualsDelegator {
+	abstract static class AbstractEqualsDelegator {
 		private final int i;
 		
 		public AbstractEqualsDelegator(int i) { this.i = i; }
@@ -220,7 +220,7 @@ public class AbstractDelegationTest extends IntegrationTestBase {
 		}
 	}
 	
-	static abstract class AbstractHashCodeDelegator {
+	abstract static class AbstractHashCodeDelegator {
 		private final int i;
 		
 		public AbstractHashCodeDelegator(int i) { this.i = i; }
@@ -244,7 +244,7 @@ public class AbstractDelegationTest extends IntegrationTestBase {
 		}
 	}
 	
-	static abstract class AbstractToStringDelegator {
+	abstract static class AbstractToStringDelegator {
 		private final int i;
 		
 		public AbstractToStringDelegator(int i) { this.i = i; }
@@ -277,7 +277,7 @@ public class AbstractDelegationTest extends IntegrationTestBase {
 		}
 	}
 	
-	static abstract class AbstractDelegator {
+	abstract static class AbstractDelegator {
 		abstract void abstractDelegation();
 		
 		private int i;
@@ -396,7 +396,7 @@ public class AbstractDelegationTest extends IntegrationTestBase {
 		}
 	}
 	
-	static abstract class ThrowsAbstractMethodErrorWithMessage {
+	abstract static class ThrowsAbstractMethodErrorWithMessage {
 		private final int i;
 		
 		public ThrowsAbstractMethodErrorWithMessage(int i) { this.i = i; }

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/ArrayTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/ArrayTest.java
@@ -279,7 +279,7 @@ public class ArrayTest extends IntegrationTestBase {
 		}
 	}
 
-	final static class TwoMultidimensionalArraysShallowHashCodeForSecond {
+	static final class TwoMultidimensionalArraysShallowHashCodeForSecond {
 		private final Object[][] first;
 		private final Object[][] second;
 

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/BalancedAbstractnessTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/BalancedAbstractnessTest.java
@@ -113,7 +113,7 @@ public class BalancedAbstractnessTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class AbstractEqualsButNotHashCode {
+	abstract static class AbstractEqualsButNotHashCode {
 		@Override
 		public abstract boolean equals(Object obj);
 	}
@@ -127,7 +127,7 @@ public class BalancedAbstractnessTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class AbstractHashCodeButNotEquals {
+	abstract static class AbstractHashCodeButNotEquals {
 		@Override
 		public abstract int hashCode();
 	}
@@ -141,7 +141,7 @@ public class BalancedAbstractnessTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 
-	static abstract class IntermediateSubclassOfAbstractBoth extends AbstractBoth {}
+	abstract static class IntermediateSubclassOfAbstractBoth extends AbstractBoth {}
 	
 	static final class SubclassOfSubclassOfAbstractBoth extends IntermediateSubclassOfAbstractBoth {
 		private final int foo;

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
@@ -257,7 +257,7 @@ public class SignificantFieldsTest extends IntegrationTestBase {
 		private final int x;
 		private final int y;
 		@SuppressWarnings("unused")
-		private transient final Color color;
+		private final transient Color color;
 		
 		public OneTransientFieldUnusedColorPoint(int x, int y, Color color) { this.x = x; this.y = y; this.color = color; }
 		

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/GetClassInEqualityComparisonTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/GetClassInEqualityComparisonTest.java
@@ -42,7 +42,7 @@ public class GetClassInEqualityComparisonTest extends IntegrationTestBase {
 				.verify();
 	}
 	
-	static abstract class Identifiable {
+	abstract static class Identifiable {
 		private final int id;
 		
 		public Identifiable(int id) { this.id = id; }

--- a/src/test/java/nl/jqno/equalsverifier/integration/inheritance/AbstractHierarchyTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/inheritance/AbstractHierarchyTest.java
@@ -51,7 +51,7 @@ public class AbstractHierarchyTest extends IntegrationTestBase {
 				.verify();
 	}
 	
-	static abstract class AbstractFinalMethodsPoint {
+	abstract static class AbstractFinalMethodsPoint {
 		private final int x;
 		private final int y;
 		
@@ -69,7 +69,7 @@ public class AbstractHierarchyTest extends IntegrationTestBase {
 		@Override public final int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class AbstractRedefinablePoint {
+	abstract static class AbstractRedefinablePoint {
 		private final int x;
 		private final int y;
 		
@@ -113,7 +113,7 @@ public class AbstractHierarchyTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class NullThrowingColorContainer {
+	abstract static class NullThrowingColorContainer {
 		private final Color color;
 		
 		public NullThrowingColorContainer(Color color) { this.color = color; }

--- a/src/test/java/nl/jqno/equalsverifier/integration/inheritance/SubclassTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/inheritance/SubclassTest.java
@@ -172,7 +172,7 @@ public class SubclassTest extends IntegrationTestBase {
 		}
 	}
 	
-	static abstract class AbstractRedefinablePoint {
+	abstract static class AbstractRedefinablePoint {
 		private final int x;
 		private final int y;
 

--- a/src/test/java/nl/jqno/equalsverifier/integration/inheritance/SuperclassTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/inheritance/SuperclassTest.java
@@ -178,7 +178,7 @@ public class SuperclassTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class EmptySubOfAbstract extends AbstractEqualsAndHashCode {}
+	abstract static class EmptySubOfAbstract extends AbstractEqualsAndHashCode {}
 	
 	static final class SubOfEmptySubOfAbstract extends EmptySubOfAbstract {
 		private final Color color;
@@ -219,7 +219,7 @@ public class SuperclassTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	public static abstract class AbstractEqualsDefiner {
+	public abstract static class AbstractEqualsDefiner {
 		@Override
 		public final boolean equals(Object obj) {
 			return EqualsBuilder.reflectionEquals(this, obj);

--- a/src/test/java/nl/jqno/equalsverifier/integration/operational/OriginalStateTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/operational/OriginalStateTest.java
@@ -119,7 +119,7 @@ public class OriginalStateTest extends IntegrationTestBase {
 		@Override public int hashCode() { return defaultHashCode(this); }
 	}
 	
-	static abstract class SuperContainer {
+	abstract static class SuperContainer {
 		private static final Object staticFinalValue = STATIC_FINAL;
 		private static Object staticValue = STATIC;
 		

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/types/TypeHelper.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/types/TypeHelper.java
@@ -230,7 +230,7 @@ public class TypeHelper {
 		public final int l = 0;
 		@SuppressWarnings("unused")
 		private static final int I = 0;
-		final static int J = 0;
+		static final int J = 0;
 		protected static final int K = 0;
 		public static final int L = 0;
 	}
@@ -251,7 +251,7 @@ public class TypeHelper {
 
 	public interface Interface {}
 	
-	public static abstract class AbstractClass {
+	public abstract static class AbstractClass {
 		int field;
 	}
 	
@@ -378,7 +378,7 @@ public class TypeHelper {
 		public int inapplicable;
 	}
 
-	public static abstract class AbstractEqualsAndHashCode {
+	public abstract static class AbstractEqualsAndHashCode {
 		@Override
 		public abstract boolean equals(Object obj);
 		

--- a/src/test/java/nl/jqno/equalsverifier/util/FormatterTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/util/FormatterTest.java
@@ -196,7 +196,7 @@ public class FormatterTest {
 		}
 	}
 	
-	static abstract class Abstract {
+	abstract static class Abstract {
 		@SuppressWarnings("unused")
 		private final int x = 10;
 		
@@ -211,7 +211,7 @@ public class FormatterTest {
 		}
 	}
 	
-	static abstract class AbstractDelegation {
+	abstract static class AbstractDelegation {
 		@SuppressWarnings("unused")
 		private final int y = 20;
 		


### PR DESCRIPTION
Java Language Specifications at [8.1.1](http://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.1.1), [8.3.1](http://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.3.1), and [8.4.3](http://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.4.3) suggests the following order:
1. public
2. protected
3. private
4. abstract
5. static
6. final
7. transient
8. volatile
9. synchronized
10. native
11. strictfp
